### PR TITLE
Refactor mapping

### DIFF
--- a/django_bend/schema.py
+++ b/django_bend/schema.py
@@ -21,24 +21,28 @@ class TableSchema:
                                 columns=columns)
         return table_obj
 
-    def has_mappings(self):
-        for col in self.columns:
-            if col.has_mapping():
-                return True
-        return False
+    def get_mapped_values(self, values):
+        # Return a copy of the values array, but with column mappings applied
+        if len(values) != len(self.columns):
+            raise Exception("Length of value array (%d) != number of columns (%d)" % (len(values), len(self.columns)))
+
+        for (column, value) in zip(self.columns, values):
+            yield column.get_target_value(value)
 
 
 class ColumnSchema:
 
-    def __init__(self, from_name, to_name, mapping=None, index=None):
+    def __init__(self, from_name, to_name, mapping=None):
         # mapping is expected to be a list of dicts
         self.from_name = from_name
         self.to_name = to_name
         self.mapping = MappingSchema(mapping)
-        self.index = index
 
-    def has_mapping(self):
-        return not self.mapping.empty()
+    #def has_mapping(self):
+    #    return not self.mapping.empty()
+
+    def get_target_value(self, value):
+        return self.mapping.map_elem(value)
 
 
 class MappingSchema:
@@ -49,14 +53,16 @@ class MappingSchema:
             for maps in mapping:
                 self.mappings.append(Mapping(from_value=maps['from'], to_value=maps['to']))
 
-    def empty(self):
-        return len(self.mappings) != 0
+    #def empty(self):
+    #    return len(self.mappings) != 0
 
     def map_elem(self, elem):
+        # if a mapping exists, return the mapped value
+        # otherwise, return the unmodified value
         for mapping in self.mappings:
             if mapping.from_value == elem:
                 return mapping.to_value
-        return None
+        return elem
 
 
 class Mapping:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -16,17 +16,37 @@ class TestMappingSchema:
         assert schema.mappings[0] == Mapping(1, True)
         assert schema.mappings[1] == Mapping(2, False)
 
+    def test_map_elem_with_match(self):
+        schema = MappingSchema([{'from': 1, 'to': True},
+                               {'from': 2, 'to': False}])
+        assert schema.map_elem(1) == True
+
+    def test_map_elem_without_match(self):
+        schema = MappingSchema([{'from': 1, 'to': True},
+                               {'from': 2, 'to': False}])
+        assert schema.map_elem(3) == 3
 
 class TestColumnSchema:
 
     def test_create_no_map(self):
         col = ColumnSchema('house', 'core.house')
+        assert col.from_name == 'house'
+        assert col.to_name == 'core.house'
+        assert isinstance(col.mapping, MappingSchema)
         assert len(col.mapping.mappings) == 0
 
     def test_with_mapping(self):
         col = ColumnSchema('house', 'core.house', [{'from': 1, 'to': True}, {'from': 2, 'to': False}])
+        assert isinstance(col.mapping, MappingSchema)
         assert len(col.mapping.mappings) == 2
 
+    def get_target_value_with_mapping(self):
+        col = ColumnSchema('house', 'core.house', [{'from': 1, 'to': True}, {'from': 2, 'to': False}])
+        assert col.get_target_value(1) == True
+
+    def get_target_value_with_mapping(self):
+        col = ColumnSchema('house', 'core.house', [{'from': 1, 'to': True}, {'from': 2, 'to': False}])
+        assert col.get_target_value(3) == 3
 
 class TestTableSchema:
 
@@ -43,6 +63,8 @@ class TestTableSchema:
                           ']')[0]
         table = TableSchema.create_from_json(data)
         assert len(table.columns) == 2
+        assert table.from_table == 'ftbl_individuals'
+        assert table.to_table == 'foo.person'
 
     def test_create_with_simple_map(self):
         data = json.loads('['
@@ -65,5 +87,5 @@ class TestTableSchema:
                           ' }'
                           ']')[0]
         table = TableSchema.create_from_json(data)
-        assert table.has_mappings()
+        assert len(table.columns) == 2
 


### PR DESCRIPTION
The intent of this PR is to make one simple change: make the `keys` argument of `create_fixture_item` a consistent type, rather than a hybrid of supporting both a dict and a list.

My idea for fixing this was to break the "mapping" part out into the `process_table` function.  While vetting that my idea was reasonable, I made so many other tweaks that I figured I should just hammer it out instead of making a suggestion.

* `map_elem(value)` now returns the `value` if a mapping isn't found.  This allows us to map all fields rather than mess with `has_mappings()` trickery

* I added `TableSchema.get_mapped_values(values_list)` which then calls map_elem on each item in the values_list

This allowed me to swap the `keys` arg for get_fixture_item back to the simpler, consistent format: a list of strings.

Let me know what you think!!